### PR TITLE
Make maximum page width configurable

### DIFF
--- a/Text/PrettyPrint/Compact.hs
+++ b/Text/PrettyPrint/Compact.hs
@@ -17,14 +17,13 @@
 -- >>> putStrLn $ render $ pretty abcd
 -- (a b c d)
 --
--- or /TODO/
+-- or
 --
--- @
+-- >>> putStrLn $ renderWith defaultOptions { optsPageWidth = 5 } $ pretty abcd
 -- (a
 --  b
 --  c
 --  d)
--- @
 --
 -- The @testData@ S-Expression is specially crafted to
 -- demonstrate general shortcomings of both Hughes and Wadler libraries.
@@ -35,9 +34,9 @@
 -- ((abcde ((a b c d) (a b c d) (a b c d) (a b c d)))
 --  (abcdefgh ((a b c d) (a b c d) (a b c d) (a b c d))))
 --
--- on 20-column-wide page: /TODO/
+-- on 20-column-wide page
 --
--- @
+-- >>> putStrLn $ renderWith defaultOptions { optsPageWidth = 20 } $ pretty testData
 -- ((abcde ((a b c d)
 --          (a b c d)
 --          (a b c d)
@@ -47,7 +46,6 @@
 --    (a b c d)
 --    (a b c d)
 --    (a b c d))))
--- @
 --
 -- Yet, neither Hughes' nor Wadler's library can deliver those results.
 --
@@ -57,7 +55,7 @@
 -- and in the rendering phase emphasise them by rendering them in uppercase.
 --
 -- >>> let pretty' :: SExpr -> Doc Any; pretty' (Atom s) = text s; pretty' (SExpr []) = text "()"; pretty' (SExpr (x:xs)) = text "(" <> (sep $ annotate (Any True) (pretty' x) : map pretty' xs) <> text ")"
--- >>> let render' = renderWith (\a x -> if a == Any True then map toUpper x else x)
+-- >>> let render' = renderWith defaultOptions { optsAnnotate  = \a x -> if a == Any True then map toUpper x else x }
 -- >>> putStrLn $ render' $ pretty' testData
 -- ((ABCDE ((A B C D) (A B C D) (A B C D) (A B C D)))
 --  (ABCDEFGH ((A B C D) (A b c d) (A b c d) (A b c d))))
@@ -94,6 +92,8 @@ module Text.PrettyPrint.Compact (
    -- * Rendering
    renderWith,
    render,
+   Options(..),
+   defaultOptions,
 
    -- * Undocumented
    -- column, nesting, width
@@ -106,7 +106,13 @@ import Text.PrettyPrint.Compact.Core as Text.PrettyPrint.Compact
 
 -- | Render the 'Doc' into 'String' omitting all annotations.
 render :: Monoid a => Doc a -> String
-render = renderWith (\_ s -> s)
+render = renderWith defaultOptions
+
+defaultOptions :: Options a String
+defaultOptions = Options
+    { optsAnnotate = \_ s -> s
+    , optsPageWidth = 80
+    }
 
 -- | The document @(list xs)@ comma separates the documents @xs@ and
 -- encloses them in square brackets. The documents are rendered

--- a/bench/Benchmark.hs
+++ b/bench/Benchmark.hs
@@ -26,7 +26,8 @@ prettiestJSON Null         = PC.mempty
 prettiestJSON (Number n)   = PC.text (show n)
 
 pcRenderText :: Monoid a => PC.Doc a -> TL.Text
-pcRenderText = TLB.toLazyText . PC.renderWith (\_ -> TLB.fromString)
+pcRenderText = TLB.toLazyText . PC.renderWith PC.defaultOptions
+    { PC.optsAnnotate = \_ -> TLB.fromString }
 
 wlJSON :: Value -> WL.Doc
 wlJSON (Bool True)     = WL.text "true"


### PR DESCRIPTION
As expected there is a slowdown, previously the first benchmark job run in 9.x ms

```
benchmarking small/pretty-compact
time                 17.98 ms   (17.39 ms .. 18.55 ms)
                     0.995 R²   (0.991 R² .. 0.998 R²)
mean                 17.42 ms   (17.05 ms .. 17.75 ms)
std dev              836.4 μs   (679.8 μs .. 1.020 ms)
variance introduced by outliers: 16% (moderately inflated)

benchmarking small/pretty-compact Text
time                 18.49 ms   (18.04 ms .. 18.96 ms)
                     0.996 R²   (0.993 R² .. 0.998 R²)
mean                 18.51 ms   (18.14 ms .. 19.00 ms)
std dev              983.5 μs   (661.1 μs .. 1.657 ms)
variance introduced by outliers: 21% (moderately inflated)

benchmarking small/pretty
time                 2.020 ms   (1.963 ms .. 2.089 ms)
                     0.991 R²   (0.986 R² .. 0.995 R²)
mean                 2.055 ms   (1.991 ms .. 2.240 ms)
std dev              360.5 μs   (139.2 μs .. 705.4 μs)
variance introduced by outliers: 87% (severely inflated)

benchmarking small/wl-pprint
time                 1.085 ms   (1.056 ms .. 1.114 ms)
                     0.991 R²   (0.986 R² .. 0.995 R²)
mean                 1.091 ms   (1.061 ms .. 1.143 ms)
std dev              126.3 μs   (84.51 μs .. 193.5 μs)
variance introduced by outliers: 78% (severely inflated)
```

yet, for *big* input, the relative slowdown is much smaller
